### PR TITLE
Make the older and newer link use the filter

### DIFF
--- a/ec.class.php
+++ b/ec.class.php
@@ -194,7 +194,7 @@ class ec_page {
 		return $ret;
 	}
 
-	 function show_gallery() {
+	function show_gallery() {
 		$full_html_dir  = $this->full_dir;
 		$thumb_html_dir = $this->thumb_dir;
 		$start          = microtime(1);

--- a/ec.class.php
+++ b/ec.class.php
@@ -330,6 +330,10 @@ class ec_page {
 		if ($shown_images >= $limit) {
 			$new_offset = $offset + $limit;
 			$older_link = "$PHP_SELF?show=gallery&amp;offset=$new_offset";
+			// If there's a filter put it in the older link
+			if (!empty($filter)) {
+				$older_link .= '&amp;filter=' . $filter;
+			}
 			$older_html = "<a href=\"$older_link\">Older</a>\n";
 		} else {
 			$older_html = "Older\n";
@@ -338,8 +342,13 @@ class ec_page {
 		// Setup the new offset link
 		if ($offset > 0) {
 			$new_offset = $offset - $limit;
+			$newer_link = "$PHP_SELF?show=gallery&amp;offset=$new_offset";
+			// If there's a filter add the filter to the newer link.
+			if (!empty($filter)) {
+				$newer_link .= '&amp;filter=' . $filter;
+			}
 			if ($new_offset < 0) { $new_offset = 0; }
-			$newer_html = "<a href=\"$PHP_SELF?show=gallery&amp;offset=$new_offset\">Newer</a>";
+			$newer_html = "<a href=\"$newer_link\">Newer</a>";
 		} else {
 			$newer_html = "Newer";
 		}


### PR DESCRIPTION
The older and newer links should use the filter if one is proved for navigation. Otherwise you are in a filter and go to older and you're not seeing what you filtered for.
