### PR TITLE
BUG FIX: Initialize the $urlt before trying to add to the variable.

### DIFF
--- a/index.php
+++ b/index.php
@@ -152,6 +152,7 @@ if (!$img_info) {
 	-->";
 
 	$show_count = 1;
+	$urlt = ''; // initalize urlt;
 	for ($i = 0; $i < $show_count; $i++) {
 		$filet  = "<input class=\"file_input\" type=\"file\" multiple=\"true\" name=\"file[]\" id=\"file-$i\" size=\"40\" />\n";
 


### PR DESCRIPTION
An E-Notice would be thrown when logging into EasyCapture when trying to
add to the $urlt variable without it being set to anything before that.
